### PR TITLE
fixes #6

### DIFF
--- a/key_convert.sh
+++ b/key_convert.sh
@@ -252,7 +252,7 @@ if [ $RETURN -ne 0 ]; then
 		[yY] | [yY][Ee][Ss] )
 			# output a decrypted key
 			OUTFILE=${KEYFILE%%.*}_decr.key
-			openssl rsa -in $KEYFILE -outform PEM -out $OUTFILE -noout  
+			openssl rsa -in $KEYFILE -outform PEM -out $OUTFILE 
 			RETURN=$?
 			if [ $RETURN -ne 0 ]; then
 				techo "*** FATAL: Couldn't decrypt key. Wrong password?"


### PR DESCRIPTION
-noout prevented the conversion from actually outputting the decrypted key, instead creating an empty output file.

This is confirmed to fix the issue.